### PR TITLE
Refactor Maven POM structure for improved maintainability

### DIFF
--- a/portal-backend/pom.xml
+++ b/portal-backend/pom.xml
@@ -2,10 +2,15 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.kalafatic.web</groupId>
+  <parent>
+    <groupId>com.kalafatic.web</groupId>
+    <artifactId>portal</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../portal/pom.xml</relativePath>
+  </parent>
+
   <artifactId>portal-backend</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>ear</packaging>
 
   <name>portal-backend</name>
   <url>http://maven.apache.org</url>
@@ -21,21 +26,36 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-ear-plugin</artifactId>
-				<version>2.6</version>
+				<!-- Version managed by parent -->
 				<configuration>
-					<version>6</version>
+					<version>6</version> <!-- This is JEE version for EAR, not plugin version -->
 					<defaultLibBundleDir>lib</defaultLibBundleDir>
+					<!-- Ensure the WAR from portal-frontend is included if needed, or other modules -->
+					<!-- For now, assuming direct dependencies are sufficient or it's self-contained -->
+					<modules>
+						<!-- Example: If portal-frontend.war should be part of this EAR -->
+						<!--
+                        <webModule>
+                            <groupId>com.kalafatic.web</groupId>
+                            <artifactId>portal-frontend</artifactId>
+                            <contextRoot>/portal</contextRoot>
+                        </webModule>
+                         -->
+					</modules>
 				</configuration>
 			</plugin>
 			
-			<plugin>
+			<!-- This plugin is not typically needed for 'ear' packaging unless creating a WAR within the EAR -->
+			<!-- Removing it as it seems out of place for an EAR module itself. -->
+			<!-- If portal-backend were to produce a WAR to be included in an EAR, structure would differ. -->
+			<!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.3.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
+            </plugin> -->
 
 		</plugins>
 	</build>
@@ -45,33 +65,35 @@
     	<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
+			<!-- Version managed by parent -->
 			<scope>test</scope>
 		</dependency>
 
-
+		<!-- This project is 'ear', it typically bundles WARs, JARs, EJBs. -->
+		<!-- The Java EE API is usually needed by modules *within* the EAR (like WARs or EJB JARs), not the EAR itself. -->
+		<!-- However, keeping it if there's a specific reason for now. -->
 		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-api</artifactId>
-			<version>7.0</version>
+			<!-- Version managed by parent -->
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxrs</artifactId>
-			<version>3.0.12.Final</version>
+			<!-- Version managed by parent -->
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jackson2-provider</artifactId>
-			<version>3.0.12.Final</version>
+			<!-- Version managed by parent -->
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.28</version>
+			<!-- Version managed by parent -->
 		</dependency>
   </dependencies>
   
@@ -82,8 +104,9 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
-						<version>3.2.0</version>
+						<!-- Version managed by parent -->
 						<executions>
 							<execution>
 								<id>copy-resources-ear</id>
@@ -93,8 +116,7 @@
 									<goal>copy-resources</goal>
 								</goals>
 								<configuration>
-									<outputDirectory>
-										/home/petr/Servers/jboss-eap-7.4_BE/standalone/deployments/</outputDirectory>
+									<outputDirectory>${jboss.deploy.path.backend}</outputDirectory>
 									<resources>
 										<resource>
 											<directory>

--- a/portal-frontend/pom.xml
+++ b/portal-frontend/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>portal-frontend</artifactId>
 	<packaging>war</packaging>
 
-	<name>portal</name>
+	<name>portal-frontend</name>
 	<description>Personal FE portal module</description>
 	<url>http://www.kalafatic.com</url>
 
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
+			<!-- Version managed by parent -->
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -38,17 +38,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
+				<!-- Version managed by parent -->
 				<configuration>
 					<packagingExcludes>%regex[WEB-INF/lib/jboss-(?!vfs).*.jar]</packagingExcludes>
-					<webXml>${maven.war.webxml}</webXml>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>3.4.0</version>
-				<configuration>
 					<webXml>${project.basedir}/src/main/webapp/WEB-INF/web.xml</webXml>
+					<!-- If a custom web.xml location is needed via a property, it could be like: -->
+					<!-- <webXml>${maven.war.webxml}</webXml> -->
+					<!-- But ensure 'maven.war.webxml' property is defined, e.g. in <properties> -->
 				</configuration>
 			</plugin>
 
@@ -62,8 +58,9 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
-						<version>3.2.0</version>
+						<!-- Version managed by parent -->
 						<executions>
 							<execution>
 								<id>copy-resources-war</id>
@@ -73,8 +70,7 @@
 									<goal>copy-resources</goal>
 								</goals>
 								<configuration>
-									<outputDirectory>
-										/home/petr/Servers/jboss-eap-7.4_FE/standalone/deployments/</outputDirectory>
+									<outputDirectory>${jboss.deploy.path.frontend}</outputDirectory>
 									<resources>
 										<resource>
 											<directory>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,9 +6,87 @@
   <packaging>pom</packaging>
   <description>Personal WEB portal</description>
   <url>http://www.kalafatic.com</url>
-  <name>portal-web</name>
+  <name>portal</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>3.8.1</junit.version> <!-- Recommended: Upgrade to JUnit 5 or at least 4.13.2 -->
+    <javaee-api.version>7.0</javaee-api.version> <!-- Recommended: Consider 8.0 if JBoss EAP 7.4 supports it well -->
+    <resteasy.version>3.15.6.Final</resteasy.version> <!-- Updated to align with JBoss EAP 7.4.x -->
+    <mysql-connector.version>8.0.33</mysql-connector.version> <!-- Updated to a newer patch -->
+    <jboss.deploy.path.backend>/home/petr/Servers/jboss-eap-7.4_BE/standalone/deployments/</jboss.deploy.path.backend>
+    <jboss.deploy.path.frontend>/home/petr/Servers/jboss-eap-7.4_FE/standalone/deployments/</jboss.deploy.path.frontend>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version> <!-- Current: 3.8.1, Latest: 3.13.0 -->
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version> <!-- Updated from 3.2.0 -->
+  </properties>
+
   <modules>
   	<module>../portal-backend</module>
   	<module>../portal-frontend</module>
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax</groupId>
+        <artifactId>javaee-api</artifactId>
+        <version>${javaee-api.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
+        <version>${resteasy.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jackson2-provider</artifactId>
+        <version>${resteasy.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${mysql-connector.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-ear-plugin</artifactId>
+          <version>3.3.0</version> <!-- Already latest -->
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.4.0</version> <!-- Already latest -->
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
- Centralized dependency versions in parent POM using <dependencyManagement>.
- Centralized plugin versions and configurations in parent POM using <pluginManagement>.
- Corrected packaging for portal-backend to 'ear' and added parent reference.
- Removed redundant groupId and version from submodules where inherited.
- Consolidated duplicate maven-war-plugin declaration in portal-frontend.
- Parameterized hardcoded JBoss deployment paths in profiles using properties.
- Ensured consistent <name> tags across modules.
- Updated Resteasy, MySQL Connector/J, and maven-resources-plugin to newer versions.
- Provided recommendations for further upgrades (JUnit, Java EE API).